### PR TITLE
Fix winsock_pointers.h missing in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include twisted_iocpsupport/*.pxi
 include twisted_iocpsupport/*.pyx
 exclude twisted_iocpsupport/*.c
-include twisted_iocpsupport/winsock_pointers.c
+include twisted_iocpsupport/*.h


### PR DESCRIPTION
## Scope and purpose

Fixes building from sdist in Windows:
```
iocpsupport.c
twisted_iocpsupport/iocpsupport.c(638): fatal error C1083: Cannot open include file: 'winsock_pointers.h': No such file or directory
error: command 'C:\\Program Files (x86)\\Microsoft Visual Studio\\2019\\Community\\VC\\Tools\\MSVC\\14.28.29333\\bin\\HostX86\\x64\\cl.exe' failed with exit status 2
```


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10103
* [x] I ran `tox -e lint` to format my patch to meet the [Twisted Coding Standard](https://twistedmatrix.com/documents/current/core/development/policy/coding-standard.html)
* [ ] I have created a newsfragment in src/twisted/newsfragments/ (see: [News files](https://twistedmatrix.com/trac/wiki/ReviewProcess#Newsfiles))
* [ ] I have updated the automated tests.
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
