### PR TITLE
upgrade to cibuildwheel 2.1.1 for 3.10 wheels

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.0.1
+          python -m pip install cibuildwheel==2.1.1
 
       - name: Build wheels
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Compile 3.10 wheels https://twistedmatrix.com/trac/ticket/10250
 
 
 1.0.1 (2021-02-28)

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:


### PR DESCRIPTION
## Scope and purpose

3.10rc1 was released with ABI stability, so it's time for 3.10 wheels


## Remove this section


## Contributor Checklist:

* [x] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/10250
* [x] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
