### PR TITLE
Upgrade to cibuildwheel 2.15.0 for python 3.12 support

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.12.1
+          python -m pip install cibuildwheel==2.15.0
 
       - name: Build wheels
         run: |

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 1.0.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Compile 3.12 wheels.
 
 
 1.0.3 (2023-03-30)

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2001-2020
+Copyright (c) 2001-2023
 Allen Short
 Amber Hawkie Brown
 Andrew Bennetts

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ classifiers =
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 packages = find:


### PR DESCRIPTION
## Scope and purpose

This PR should add support for upcoming Python 3.12

## Contributor Checklist:

* [ ] The associated ticket in Trac is here: https://twistedmatrix.com/trac/ticket/<!-- Create a new one at https://twistedmatrix.com/trac/newticket and replace this comment with the ticket number. -->
* [ ] I have submitted the associated Trac ticket for review by adding the word `review` to the keywords field in Trac, and putting a link to this PR in the comment; it shows up in https://twisted.reviews/ now.
