### PR TITLE
Release 25.2

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -77,10 +77,6 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
-    # upload to PyPI on every tag starting with 'v'
-    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v')
-    # alternatively, to publish when a GitHub Release is created, use the following rule:
-    # if: github.event_name == 'release' && github.event.action == 'published'
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -91,8 +87,7 @@ jobs:
       - name: Check files
         run: ls -al dist/
 
-      - uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
-          # To test: repository_url: https://test.pypi.org/legacy/
+      - name: Publish to PyPI - on tag
+        # Skip upload to PyPI if we don't have a tag
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -7,7 +7,7 @@ on:
     # We should make sure to only push tags for new releases.
     # If we start using tags for non-release purposes,
     # this needs to be updated.
-    tags:
+    tags: [ "**" ]
   pull_request:
 
 jobs:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -74,7 +74,7 @@ jobs:
           path: dist/*.tar.gz
 
   upload_pypi:
-    needs: [build_wheels, build_sdist]
+    needs: [build_wheels, build_sdist, check_manifest]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - trunk
+    # To simplify the release process, the publishing is triggred on any push tag.
+    # We should make sure to only push tags for new releases.
+    # If we start using tags for non-release purposes,
+    # this needs to be updated.
     tags:
   pull_request:
 

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -3,10 +3,12 @@ on:
   push:
     branches:
       - trunk
-    # To simplify the release process, the publishing is triggred on any push tag.
+    # To simplify the release process, the publishing is triggered on tag.
     # We should make sure to only push tags for new releases.
     # If we start using tags for non-release purposes,
     # this needs to be updated.
+    #
+    # We need to explicitly configure an expression that matches anything.
     tags: [ "**" ]
   pull_request:
 

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -2,9 +2,9 @@ name: Build and upload to PyPI
 on:
   push:
     branches:
-      - default
+      - trunk
     tags:
-      - v*
+      - *
   pull_request:
 
 jobs:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - trunk
     tags:
-      - *
   pull_request:
 
 jobs:

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -82,6 +82,9 @@ jobs:
   upload_pypi:
     needs: [build_wheels, build_sdist, check_manifest]
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
     steps:
       - uses: actions/download-artifact@v4
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+
+25.2.0 (2025-02-27)
+-------------------
+
+- Add support for Python 3.13 wheels.
+- Add support for Python 3.13 free threading wheels.
+
+
 1.0.4 (2023-08-10)
 ------------------
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,5 @@ include LICENSE
 exclude CHANGELOG.rst
 exclude CONTRIBUTING.rst
 exclude SECURITY.md
+exclude RELEASE.rst
 exclude .pre-commit-config.yaml

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -10,12 +10,20 @@ To do a release, follow these steps:
 * Update the `Changelog.rst` file with the summary of the changes.
 * Commit the changes to GitHub and create a PR
 * Request the review from `twisted-contributors` team.
-* Once the PR is approved create a `git tag` based on the latest commit from
-  the PR.
-  The tag name should be the current version.
-* Push the tag to Github.
-  This will automatically trigger the build process for the wheels and will
-  publish them to PyPI
+* Once the PR is approved, create a new release via `GitHub Releases<https://github.com/twisted/twisted-iocpsupport/releases/new>`_.
+  The tag name should be the current version. Select to create a new tag.
+  Select the release branch as the target branch.
+  Copy/paste the release notes.
+* Publish the release.
+  This will automatically trigger that creation of a new that,
+  which in turn will trigger the build process for the wheels and will
+  publish them to PyPI.
+
+Using GitHub Releases is not required.
+You can also just create and push a new tag.
+It will still trigger the publish process.
+
+GitHub Release should just make it a bit easier to detect the release of this project.
 
 
 Implementation details

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,0 +1,36 @@
+How to do a release
+###################
+
+We use calendar versioning, similar to the `twisted/twisted` project.
+
+To do a release, follow these steps:
+
+* Create a new branch. You can name the branch `release-YEAR.MONTH`.
+* Update the `[metadata] version` inside `setup.cfg`
+* Update the `Changelog.rst` file with the summary of the changes.
+* Commit the changes to GitHub and create a PR
+* Request the review from `twisted-contributors` team.
+* Once the PR is approved create a `git tag` based on the latest commit from
+  the PR.
+  The tag name should be in the format `vYEAR.MONTH.NUMBER`.
+  That is, it should start with lowecase `v` followed by the version.
+* Push the tag to Github.
+  This will automatically trigger the build process for the wheels and will
+  publish them to PyPI
+
+
+Implementation details
+======================
+
+The binary wheels are generated using `cibuildwheel`.
+To build wheels for newer Python version you might need to update the version
+of `cibuildwheel`.
+
+To disable building binaries for older Python version you might need to
+edit the `[tool.cibuildwheel]` section from the `pyproject.toml` file.
+
+GitHub Action is used to run `cibuildwheel` to generate the wheels on any
+commit pushed to the main branch, to a PR or a tag.
+
+Any tag pushed that has a name starting with `v` will trigger the publishing
+to the production PyPI site.

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -12,8 +12,7 @@ To do a release, follow these steps:
 * Request the review from `twisted-contributors` team.
 * Once the PR is approved create a `git tag` based on the latest commit from
   the PR.
-  The tag name should be in the format `vYEAR.MONTH.NUMBER`.
-  That is, it should start with lowecase `v` followed by the version.
+  The tag name should be the current version.
 * Push the tag to Github.
   This will automatically trigger the build process for the wheels and will
   publish them to PyPI
@@ -21,6 +20,9 @@ To do a release, follow these steps:
 
 Implementation details
 ======================
+
+To publish to PyPi, the GitHub Action workflow needs to be named `github-deploy.yml`.
+You can `reconfigure this via PyPi <https://pypi.org/manage/project/twisted-iocpsupport/settings/publishing/>`_.
 
 The binary wheels are generated using `cibuildwheel`.
 To build wheels for newer Python version you might need to update the version

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = twisted-iocpsupport
-version = 1.0.4
+version = 25.2.0
 description = An extension for use in the twisted I/O Completion Ports reactor.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## Scope and purpose

This is to trigger a new release.


## Changes

This tries to get the project in line with other Twisted projects.
I have used `twisted/towncrier` as a model.

* Rename the default branch to `trunk`
* Use CalVer for version numbers
* Add documentation about the release process
* Update GitHub Action to do the release
* GitHub branch protection was updated to only block on `upload_pypi` . This is the task that depends on all the others. This should also help show the task sooner in the GitHub PR UI

--------

The PyPi trusted publisher is configured as below
 
![image](https://github.com/user-attachments/assets/6233c764-9f62-4650-8121-12fb2d218053)


------

I have removed the repo secret that was used in the past to publish.

I guess that this was a personal PyPi key... I don't know whose key was this.

![image](https://github.com/user-attachments/assets/69c9af40-43d1-4bd7-b050-84c1030208a0)
