### PR TITLE
#12513 Enable Python 3.14 wheel

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.22.0
+          python -m pip install cibuildwheel==3.2.1
 
       - name: Build wheels
         run: |

--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -32,8 +32,8 @@ jobs:
         run: python -m check_manifest
 
   build_wheels:
-    name: Build wheels on windows-latest
-    runs-on: windows-latest
+    name: Build wheels on windows
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,11 +2,11 @@ Changelog
 =========
 
 
-25.10.0 (2025-19-27)
+25.10.1 (2025-19-27)
 -------------------
 
 - Add support for Python 3.14 wheels.
-- Add support for Python 3.14 free threading wheels.
+- Free threading wheels builds were removed.
 
 
 25.2.0 (2025-02-27)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@ Changelog
 =========
 
 
+25.10.0 (2025-19-27)
+-------------------
+
+- Add support for Python 3.14 wheels.
+- Add support for Python 3.14 free threading wheels.
+
+
 25.2.0 (2025-02-27)
 -------------------
 

--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -8,6 +8,8 @@ To do a release, follow these steps:
 * Create a new branch. You can name the branch `release-YEAR.MONTH`.
 * Update the `[metadata] version` inside `setup.cfg`
 * Update the `Changelog.rst` file with the summary of the changes.
+* Update the version of `cibuildwheel` used  in `.github/workflows/github-deploy.yml`.
+  Most probably you need a newer version that supports newer Python versions.
 * Commit the changes to GitHub and create a PR
 * Request the review from `twisted-contributors` team.
 * Once the PR is approved, create a new release via `GitHub Releases<https://github.com/twisted/twisted-iocpsupport/releases/new>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
+enable = ["cpython-freethreading"]
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,4 @@ enable = ['all']
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 
-build = "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"
+build = "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,10 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-enable = ["cpython-freethreading", "pypy"]
+# See https://cibuildwheel.pypa.io/en/stable/options/#enable
+# ... to enable/disable it per platform or python version,
+# set this option to true and use build/skip options to filter the builds.
+enable = true
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-enable = ["cpython-freethreading"]
+enable = ["cpython-freethreading", "pypy"]
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ build-backend = "setuptools.build_meta"
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 
-build = "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"
+build = "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,4 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 enable = ["cpython-freethreading"]
-skip = "cp36-* cp37-*"
+# See the list of supported platforms
+# https://cibuildwheel.pypa.io/en/stable/options/#build-skip
+# We explictly select which Windows we want to support. 
+build = "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-enable = ["cpython-freethreading"]
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 
-build = "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"
+build = "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ build-backend = "setuptools.build_meta"
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 
-build = "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"
+build = "cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,4 @@ enable = ['all']
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 
-build = "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64"
+build = "cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp314-win_amd64 pp310-win_amd64 pp311-win_amd64"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,7 @@ requires = [
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-# See https://cibuildwheel.pypa.io/en/stable/options/#enable
-# ... to enable/disable it per platform or python version,
-# set this option to true and use build/skip options to filter the builds.
-enable = true
+enable = ['all']
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = twisted-iocpsupport
-version = 25.2.0
+version = 25.10.0
 description = An extension for use in the twisted I/O Completion Ports reactor.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
@@ -10,16 +10,16 @@ maintainer = Thomas Grainger
 maintainer_email = twisted-iocpsupport@graingert.co.uk
 url = https://github.com/twisted/twisted-iocpsupport
 license = MIT
-python_requires = >=3.8
+python_requires = >=3.9
 classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
     Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
 
 [options]
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = twisted-iocpsupport
-version = 25.10.0
+version = 25.10.1
 description = An extension for use in the twisted I/O Completion Ports reactor.
 long_description = file: README.rst
 long_description_content_type = text/x-rst


### PR DESCRIPTION
## Scope and purpose

This is to help fix this twisted/twisted issue https://github.com/twisted/twisted/issues/12513

Rather than skipping selected platforms, this change explicitly selects which platforms are builds.

This disables Windows 32bit ... as it was failing with Python 3.13t ...and I don't think that people are using Windows 32bit these days.

3.13t were also failing on 64bit , as the root cause was Windows 2025 build environment.

I have reconfigured GitHub Action to run on Windows 2022, as before with 3.13 and 3.14 threading enabled

I have updated the version to prepare for a future release... as this needs to be released so that we can enable the IOCP tests on Python 3.14 for twisted/twisted
