### PR TITLE
Build CPython 3.12 Windows ARM64 wheel

### DIFF
--- a/.github/workflows/github-deploy.yml
+++ b/.github/workflows/github-deploy.yml
@@ -32,8 +32,22 @@ jobs:
         run: python -m check_manifest
 
   build_wheels:
-    name: Build wheels on windows
-    runs-on: windows-2022
+    name: Build wheels on ${{ matrix.arch }}
+    strategy:
+      matrix:
+        include:
+          - arch: x64
+            runner: windows-2022
+            build: cp39-win_amd64 cp310-win_amd64 cp311-win_amd64 cp312-win_amd64 cp313-win_amd64 cp313t-win_amd64 cp314-win_amd64 cp314t-win_amd64 pp310-win_amd64 pp311-win_amd64
+            cibw_archs: AMD64
+          - arch: ARM64
+            runner: windows-11-arm
+            build: cp312-win_arm64
+            cibw_archs: ARM64
+    runs-on: ${{ matrix.runner }}
+    env:
+      CIBW_BUILD: ${{ matrix.build }}
+      CIBW_ARCHS_WINDOWS: ${{ matrix.cibw_archs }}
 
     steps:
       - uses: actions/checkout@v4
@@ -53,7 +67,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: artifact-wheels
+          name: artifact-wheels-${{ matrix.arch }}
           path: ./wheelhouse/*.whl
 
   build_sdist:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
 enable = ['all']
+test-command = 'python -c "from twisted_iocpsupport.iocpsupport import CompletionPort; CompletionPort()"'
 # See the list of supported platforms
 # https://cibuildwheel.pypa.io/en/stable/options/#build-skip
 # We explictly select which Windows we want to support. 


### PR DESCRIPTION
## Summary
- build a native CPython 3.12 Windows ARM64 wheel on `windows-11-arm`
- smoke-test the compiled extension by creating an IO completion port
- preserve the existing x64 wheel matrix

## Scope
One commit changing only wheel build configuration and package metadata.

## Evidence
The native ARM64 wheel built, installed, and passed `CompletionPort()` during the successful Cura package proof: https://github.com/yeelam-gordon/Cura/actions/runs/33557522209

Without this wheel, Windows ARM64 consumers fall back to an sdist whose bootstrapped Cython extension cannot load natively.

This is a dependency prerequisite for Ultimaker/Cura#21773.
